### PR TITLE
Fix GitHub Action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,11 +132,6 @@ jobs:
         cd build
         mv output.img $IMAGE.img
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ env.IMAGE }}
-        path: build/${{ env.IMAGE }}.img
-
     - name: "📝 Prepare release"
       if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
       run: |
@@ -188,3 +183,11 @@ jobs:
           build/rpi-imager.json
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "⬆ Upload build artifact"
+      uses: actions/upload-artifact@v2
+      if: github.event_name == 'push'
+      with:
+        name: ${{ env.IMAGE }}
+        path: build/${{ env.IMAGE }}.img
+


### PR DESCRIPTION
Can be triggered automatically through repository dispatch & manually through workflow dispatch, allowing to specify
the OctoPi version to build against.

Also triggers on pushes to any branch.

Runs a build and for pushes uploads the resulting output image as build artifact. In case of dispatch creates a new release and publishes the artifacts and an rpi-imager.json snippet that way.

For an example result (with the rpi-imager.json snippet pointing to the wrong download URL however, as that's already tailored towards your repo here) see https://github.com/foosel/OctoPi-Klipper-CustoPiZer/releases/tag/0.18.0.klipper.20211026092122